### PR TITLE
[Fix] Resolve product class updating to None in Django 3.2

### DIFF
--- a/oscar_odin/mappings/context.py
+++ b/oscar_odin/mappings/context.py
@@ -4,7 +4,7 @@ from operator import attrgetter
 from django.db import transaction
 from django.core.exceptions import ValidationError
 
-from oscar_odin.utils import in_bulk
+from oscar_odin.utils import in_bulk, prepare_related_fields_for_save
 from oscar_odin.exceptions import OscarOdinException
 
 from oscar.core.loading import get_model
@@ -182,6 +182,10 @@ class ModelMapperContext(dict):
 
         fields = self.get_fields_to_update(self.Model)
         if fields is not None:
+            for instance in instances_to_update:
+                prepare_related_fields_for_save(
+                    instance, operation_name="bulk_update", fields=fields
+                )
             self.Model.objects.bulk_update(instances_to_update, fields=fields)
 
     def bulk_update_or_create_one_to_many(self):

--- a/oscar_odin/mappings/context.py
+++ b/oscar_odin/mappings/context.py
@@ -4,7 +4,7 @@ from operator import attrgetter
 from django.db import transaction
 from django.core.exceptions import ValidationError
 
-from oscar_odin.utils import in_bulk, prepare_related_fields_for_save
+from oscar_odin.utils import in_bulk
 from oscar_odin.exceptions import OscarOdinException
 
 from oscar.core.loading import get_model
@@ -183,9 +183,8 @@ class ModelMapperContext(dict):
         fields = self.get_fields_to_update(self.Model)
         if fields is not None:
             for instance in instances_to_update:
-                prepare_related_fields_for_save(
-                    instance, operation_name="bulk_update", fields=fields
-                )
+                # This should be removed once support for django 3.2 is dropped
+                instance._prepare_related_fields_for_save("bulk_update")
             self.Model.objects.bulk_update(instances_to_update, fields=fields)
 
     def bulk_update_or_create_one_to_many(self):

--- a/oscar_odin/utils.py
+++ b/oscar_odin/utils.py
@@ -72,3 +72,77 @@ def querycounter(*labels, print_queries=False):
     if print_queries:
         for q in connection.queries:
             print("   ", q)
+
+
+def prepare_related_fields_for_save(instance, operation_name, fields):
+    """
+    This function is taken from models.Model django 4.0,
+    It can be used alongside bulk_update for products like:
+
+    for instance in instances_to_update:
+        prepare_related_fields_for_save(
+            instance, operation_name="bulk_update", fields=fields
+        )
+    self.Model.objects.bulk_update(instances_to_update, fields=fields)
+
+    This method can be removed when oscar odin drops django 3.2 support.
+    """
+    fields = [instance._meta.get_field(name) for name in fields]
+    if any(not f.concrete or f.many_to_many for f in fields):
+        raise ValueError("bulk_update() can only be used with concrete fields.")
+    if any(f.primary_key for f in fields):
+        raise ValueError("bulk_update() cannot be used with primary key fields.")
+
+    # Ensure that a model instance without a PK hasn't been assigned to
+    # a ForeignKey, GenericForeignKey or OneToOneField on this model. If
+    # the field is nullable, allowing the save would result in silent data
+    # loss.
+    for field in instance._meta.concrete_fields:
+        if fields and field not in fields:
+            continue
+        # If the related field isn't cached, then an instance hasn't been
+        # assigned and there's no need to worry about this check.
+        if field.is_relation and field.is_cached(instance):
+            obj = getattr(instance, field.name, None)
+            if not obj:
+                continue
+            # A pk may have been assigned manually to a model instance not
+            # saved to the database (or auto-generated in a case like
+            # UUIDField), but we allow the save to proceed and rely on the
+            # database to raise an IntegrityError if applicable. If
+            # constraints aren't supported by the database, there's the
+            # unavoidable risk of data corruption.
+            if obj.pk is None:
+                # Remove the object from a related instance cache.
+                if not field.remote_field.multiple:
+                    field.remote_field.delete_cached_value(obj)
+                raise ValueError(
+                    "%s() prohibited to prevent data loss due to unsaved "
+                    "related object '%s'." % (operation_name, field.name)
+                )
+            elif getattr(instance, field.attname) in field.empty_values:
+                # Set related object if it has been saved after an
+                # assignment.
+                setattr(instance, field.name, obj)
+            # If the relationship's pk/to_field was changed, clear the
+            # cached relationship.
+            if getattr(obj, field.target_field.attname) != getattr(
+                instance, field.attname
+            ):
+                field.delete_cached_value(instance)
+
+    # GenericForeignKeys are private.
+    for field in instance._meta.private_fields:
+        if fields and field not in fields:
+            continue
+        if (
+            field.is_relation
+            and field.is_cached(instance)
+            and hasattr(field, "fk_field")
+        ):
+            obj = field.get_cached_value(instance, default=None)
+            if obj and obj.pk is None:
+                raise ValueError(
+                    f"{operation_name}() prohibited to prevent data loss due to "
+                    f"unsaved related object '{field.name}'."
+                )

--- a/oscar_odin/utils.py
+++ b/oscar_odin/utils.py
@@ -1,13 +1,10 @@
+from collections import defaultdict
 import contextlib
 import time
 import math
 
-from django.db import connection, reset_queries
-
-from collections import defaultdict
-
-from django.db.models import Model, ManyToManyField, ForeignKey, Q
-from django.db import connections
+from django.db import connection, connections, reset_queries
+from django.db.models import Q
 
 
 def get_filters(instances, field_names):
@@ -72,77 +69,3 @@ def querycounter(*labels, print_queries=False):
     if print_queries:
         for q in connection.queries:
             print("   ", q)
-
-
-def prepare_related_fields_for_save(instance, operation_name, fields):
-    """
-    This function is taken from models.Model django 4.0,
-    It can be used alongside bulk_update for products like:
-
-    for instance in instances_to_update:
-        prepare_related_fields_for_save(
-            instance, operation_name="bulk_update", fields=fields
-        )
-    self.Model.objects.bulk_update(instances_to_update, fields=fields)
-
-    This method can be removed when oscar odin drops django 3.2 support.
-    """
-    fields = [instance._meta.get_field(name) for name in fields]
-    if any(not f.concrete or f.many_to_many for f in fields):
-        raise ValueError("bulk_update() can only be used with concrete fields.")
-    if any(f.primary_key for f in fields):
-        raise ValueError("bulk_update() cannot be used with primary key fields.")
-
-    # Ensure that a model instance without a PK hasn't been assigned to
-    # a ForeignKey, GenericForeignKey or OneToOneField on this model. If
-    # the field is nullable, allowing the save would result in silent data
-    # loss.
-    for field in instance._meta.concrete_fields:
-        if fields and field not in fields:
-            continue
-        # If the related field isn't cached, then an instance hasn't been
-        # assigned and there's no need to worry about this check.
-        if field.is_relation and field.is_cached(instance):
-            obj = getattr(instance, field.name, None)
-            if not obj:
-                continue
-            # A pk may have been assigned manually to a model instance not
-            # saved to the database (or auto-generated in a case like
-            # UUIDField), but we allow the save to proceed and rely on the
-            # database to raise an IntegrityError if applicable. If
-            # constraints aren't supported by the database, there's the
-            # unavoidable risk of data corruption.
-            if obj.pk is None:
-                # Remove the object from a related instance cache.
-                if not field.remote_field.multiple:
-                    field.remote_field.delete_cached_value(obj)
-                raise ValueError(
-                    "%s() prohibited to prevent data loss due to unsaved "
-                    "related object '%s'." % (operation_name, field.name)
-                )
-            elif getattr(instance, field.attname) in field.empty_values:
-                # Set related object if it has been saved after an
-                # assignment.
-                setattr(instance, field.name, obj)
-            # If the relationship's pk/to_field was changed, clear the
-            # cached relationship.
-            if getattr(obj, field.target_field.attname) != getattr(
-                instance, field.attname
-            ):
-                field.delete_cached_value(instance)
-
-    # GenericForeignKeys are private.
-    for field in instance._meta.private_fields:
-        if fields and field not in fields:
-            continue
-        if (
-            field.is_relation
-            and field.is_cached(instance)
-            and hasattr(field, "fk_field")
-        ):
-            obj = field.get_cached_value(instance, default=None)
-            if obj and obj.pk is None:
-                raise ValueError(
-                    f"{operation_name}() prohibited to prevent data loss due to "
-                    f"unsaved related object '{field.name}'."
-                )


### PR DESCRIPTION
When we use django 3.2 with postgres, bulk_update sets product_class to None. This PR resolves this error by using the prepare_related_fields_for_save method present in models.Model class of django 4.