### PR TITLE
[FEAT] Prefetch attributes to reduce query count

### DIFF
--- a/oscar_odin/mappings/catalogue.py
+++ b/oscar_odin/mappings/catalogue.py
@@ -427,6 +427,7 @@ def products_to_db(
     identifier_mapping=MODEL_IDENTIFIERS_MAPPING,
     product_mapper=ProductToModel,
     delete_related=False,
+    clean_instances=True,
 ) -> Tuple[List[ProductModel], Dict]:
     """Map mulitple products to a model and store them in the database.
 
@@ -444,7 +445,10 @@ def products_to_db(
     )
 
     products, errors = context.bulk_save(
-        instances, fields_to_update, identifier_mapping
+        instances,
+        fields_to_update,
+        identifier_mapping,
+        clean_instances,
     )
 
     return products, errors

--- a/oscar_odin/mappings/catalogue.py
+++ b/oscar_odin/mappings/catalogue.py
@@ -427,7 +427,6 @@ def products_to_db(
     identifier_mapping=MODEL_IDENTIFIERS_MAPPING,
     product_mapper=ProductToModel,
     delete_related=False,
-    product_class=None,
 ) -> Tuple[List[ProductModel], Dict]:
     """Map mulitple products to a model and store them in the database.
 
@@ -445,7 +444,7 @@ def products_to_db(
     )
 
     products, errors = context.bulk_save(
-        instances, fields_to_update, identifier_mapping, product_class=product_class
+        instances, fields_to_update, identifier_mapping
     )
 
     return products, errors

--- a/oscar_odin/mappings/catalogue.py
+++ b/oscar_odin/mappings/catalogue.py
@@ -427,6 +427,7 @@ def products_to_db(
     identifier_mapping=MODEL_IDENTIFIERS_MAPPING,
     product_mapper=ProductToModel,
     delete_related=False,
+    product_class=None,
 ) -> Tuple[List[ProductModel], Dict]:
     """Map mulitple products to a model and store them in the database.
 
@@ -444,7 +445,7 @@ def products_to_db(
     )
 
     products, errors = context.bulk_save(
-        instances, fields_to_update, identifier_mapping
+        instances, fields_to_update, identifier_mapping, product_class=product_class
     )
 
     return products, errors

--- a/oscar_odin/mappings/context.py
+++ b/oscar_odin/mappings/context.py
@@ -80,15 +80,21 @@ class ModelMapperContext(dict):
 
     def validate_instances(self, instances, validate_unique=True, fields=None):
         validated_instances = []
-        instance_ids = []
+        identities = []
         exclude = ()
         if fields and instances:
             all_fields = instances[0]._meta.fields
             exclude = [f.name for f in all_fields if f.name not in fields]
 
+        try:
+            identifier = self.identifier_mapping.get(instances[0].__class__)[0]
+        except (IndexError, TypeError):
+            identifier = None
+
         for instance in instances:
-            if instance.id not in instance_ids:
-                instance_ids.append(instance.id)
+            if identifier is None or getattr(instance, identifier) not in identities:
+                if identifier is not None:
+                    identities.append(getattr(instance, identifier))
                 try:
                     if hasattr(instance, "attr") and self.attributes:
                         instance.attr.cache.set_attributes(self.attributes)

--- a/oscar_odin/mappings/context.py
+++ b/oscar_odin/mappings/context.py
@@ -410,9 +410,10 @@ class ProductModelMapperContext(ModelMapperContext):
     attributes = defaultdict(list)
 
     def set_product_class_attributes(self, instance):
-        key = getattr(instance.product_class, self.product_class_identifier)
-        if key and key in self.attributes:
-            instance.attr.cache.set_attributes(self.attributes[key])
+        if instance.product_class:
+            key = getattr(instance.product_class, self.product_class_identifier)
+            if key and key in self.attributes:
+                instance.attr.cache.set_attributes(self.attributes[key])
 
     def validate_instances(self, instances, validate_unique=True, fields=None):
         validated_instances = []

--- a/oscar_odin/utils.py
+++ b/oscar_odin/utils.py
@@ -12,17 +12,20 @@ from odin.mapping import MappingResult
 
 
 def get_filters(instances, field_names):
+    filters = []
     for ui in instances:
         klaas = {}
         for field_name in field_names:
             field_value = getattr(ui, field_name)
-            klaas[field_name] = field_value
-
-        yield Q(**klaas)
+            if field_value not in filters:
+                filters.append(field_value)
+                klaas[field_name] = field_value
+        if klaas:
+            yield Q(**klaas)
 
 
 def get_query(instances, field_names):
-    filters = set((get_filters(instances, field_names)))
+    filters = list((get_filters(instances, field_names)))
 
     query = filters.pop()
     for query_filter in filters:

--- a/oscar_odin/utils.py
+++ b/oscar_odin/utils.py
@@ -12,16 +12,13 @@ from odin.mapping import MappingResult
 
 
 def get_filters(instances, field_names):
-    filters = []
     for ui in instances:
         klaas = {}
         for field_name in field_names:
             field_value = getattr(ui, field_name)
-            if field_value not in filters:
-                filters.append(field_value)
-                klaas[field_name] = field_value
-        if klaas:
-            yield Q(**klaas)
+            klaas[field_name] = field_value
+
+        yield Q(**klaas)
 
 
 def get_query(instances, field_names):

--- a/oscar_odin/utils.py
+++ b/oscar_odin/utils.py
@@ -22,7 +22,7 @@ def get_filters(instances, field_names):
 
 
 def get_query(instances, field_names):
-    filters = list(get_filters(instances, field_names))
+    filters = set((get_filters(instances, field_names)))
 
     query = filters.pop()
     for query_filter in filters:

--- a/poetry.lock
+++ b/poetry.lock
@@ -600,13 +600,13 @@ elasticsearch = ["elasticsearch (>=5,<8)"]
 
 [[package]]
 name = "django-oscar"
-version = "3.2.4"
+version = "3.2.5a2"
 description = "A domain-driven e-commerce framework for Django"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "django-oscar-3.2.4.tar.gz", hash = "sha256:79a48dfd3cd9a6d93636e55bc7cba25abb56c05c200fcd0c0f30face9566a998"},
-    {file = "django_oscar-3.2.4-py3-none-any.whl", hash = "sha256:22d2f2725ba273335f12f28bf7ed79f49a63ee2d16bd842e103c90b2a65bb504"},
+    {file = "django-oscar-3.2.5a2.tar.gz", hash = "sha256:7748d142751c312c515a8fd71dd67a0db48d0eceb078edf4af53c66973da28eb"},
+    {file = "django_oscar-3.2.5a2-py3-none-any.whl", hash = "sha256:c54d80c939bd8fa840970653f364014d8decc4ef5a91e79a33a9a6fed2eb1cff"},
 ]
 
 [package.dependencies]
@@ -1530,6 +1530,7 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
     {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
     {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
     {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
     {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
@@ -2012,4 +2013,4 @@ test = ["black", "coverage", "poetry", "pylint", "pylint-django", "responses", "
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "74ba7f8e38f299b88cdd0ec80aa408ea03c58a3b2b6ea5f6dd591635b8f42d62"
+content-hash = "b51b0fd2bd39059cec5d7732f5c2c91cf30da653bfa9d94dea898095647b177f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
-django-oscar = {version = "^3.2.5", allow-prereleases = true}
+django-oscar = {version = "^3.2.4", allow-prereleases = true}
 coverage = { version = "^7.3", optional = true }
 pylint = { version = "^3.0.2", optional = true }
 black = { version = "^23.11.0", optional = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
-django-oscar = {version = "^3.2.2", allow-prereleases = true}
+django-oscar = {version = "^3.2.*", allow-prereleases = true}
 coverage = { version = "^7.3", optional = true }
 pylint = { version = "^3.0.2", optional = true }
 black = { version = "^23.11.0", optional = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
-django-oscar = {version = "^3.2.*", allow-prereleases = true}
+django-oscar = {version = "^3.2.5", allow-prereleases = true}
 coverage = { version = "^7.3", optional = true }
 pylint = { version = "^3.0.2", optional = true }
 black = { version = "^23.11.0", optional = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
-django-oscar = {version = "<3.2.6", allow-prereleases = true}
+django-oscar = {version = "^3.2.5a2", allow-prereleases = true}
 coverage = { version = "^7.3", optional = true }
 pylint = { version = "^3.0.2", optional = true }
 black = { version = "^23.11.0", optional = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
-django-oscar = {version = "^3.2.4", allow-prereleases = true}
+django-oscar = {version = ">3.2.4", allow-prereleases = true}
 coverage = { version = "^7.3", optional = true }
 pylint = { version = "^3.0.2", optional = true }
 black = { version = "^23.11.0", optional = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
-django-oscar = {version = ">3.2.4", allow-prereleases = true}
+django-oscar = {version = "^3.2.5*", allow-prereleases = true}
 coverage = { version = "^7.3", optional = true }
 pylint = { version = "^3.0.2", optional = true }
 black = { version = "^23.11.0", optional = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
-django-oscar = {version = "^3.2.5*", allow-prereleases = true}
+django-oscar = {version = "<3.2.6", allow-prereleases = true}
 coverage = { version = "^7.3", optional = true }
 pylint = { version = "^3.0.2", optional = true }
 black = { version = "^23.11.0", optional = true }


### PR DESCRIPTION
Use ProductAttributeContainer's cache set_attributes method to set all attributes instead of fetching it twice per product. This is helpful when bulk of the products are associated with the same product.