### PR TITLE
Allow setting product on product image resource

### DIFF
--- a/oscar_odin/resources/catalogue.py
+++ b/oscar_odin/resources/catalogue.py
@@ -46,6 +46,8 @@ class ProductImageResource(OscarCatalogueResource):
     )
     date_created: Optional[datetime]
 
+    product: Optional["ProductResource"] = odin.DictOf.delayed(lambda: ProductResource)
+
 
 class CategoryResource(OscarCatalogueResource):
     """A category within Django Oscar."""


### PR DESCRIPTION
So you can save product images independently of the products mapping.