### PR TITLE
Added tools to track which fields_to_update after mapping.

### DIFF
--- a/oscar_odin/mappings/constants.py
+++ b/oscar_odin/mappings/constants.py
@@ -17,6 +17,7 @@ PRODUCT_DESCRIPTION = "Product.description"
 PRODUCT_META_TITLE = "Product.meta_title"
 PRODUCT_META_DESCRIPTION = "Product.meta_description"
 PRODUCT_IS_DISCOUNTABLE = "Product.is_discountable"
+PRODUCT_PRIORITY = "Product.priority"
 
 PRODUCTCLASS_SLUG = "ProductClass.slug"
 PRODUCTCLASS_REQUIRESSHIPPING = "ProductClass.requires_shipping"
@@ -55,7 +56,7 @@ ALL_PRODUCT_FIELDS = [
     PRODUCT_META_TITLE,
     PRODUCT_META_DESCRIPTION,
     PRODUCT_IS_DISCOUNTABLE,
-    PRODUCT_PARENT,
+    PRODUCT_PRIORITY,
 ]
 
 ALL_PRODUCTCLASS_FIELDS = [

--- a/tests/mappings/test_catalogue.py
+++ b/tests/mappings/test_catalogue.py
@@ -6,6 +6,8 @@ from oscar.core.loading import get_model
 
 from oscar_odin.mappings import catalogue
 
+from oscar_odin.utils import get_mapped_fields
+
 Product = get_model("catalogue", "Product")
 
 
@@ -75,3 +77,127 @@ class TestProduct(TestCase):
                 queryset, include_children=True
             )
             dict_codec.dump(resources, include_type_field=False)
+
+    def test_get_mapped_fields(self):
+        product_to_model_fields = get_mapped_fields(catalogue.ProductToModel)
+        self.assertListEqual(
+            sorted(product_to_model_fields),
+            [
+                "attributes",
+                "categories",
+                "children",
+                "date_created",
+                "date_updated",
+                "description",
+                "id",
+                "images",
+                "is_discountable",
+                "is_public",
+                "meta_description",
+                "meta_title",
+                "parent",
+                "priority",
+                "product_class",
+                "rating",
+                "recommended_products",
+                "slug",
+                "stockrecords",
+                "structure",
+                "title",
+                "upc",
+            ],
+        )
+
+        model_to_product_fields = get_mapped_fields(catalogue.ProductToResource)
+        self.assertListEqual(
+            sorted(model_to_product_fields),
+            [
+                "attributes",
+                "availability",
+                "categories",
+                "children",
+                "currency",
+                "date_created",
+                "date_updated",
+                "description",
+                "id",
+                "images",
+                "is_available_to_buy",
+                "is_discountable",
+                "is_public",
+                "meta_description",
+                "meta_title",
+                "parent",
+                "price",
+                "priority",
+                "product_class",
+                "rating",
+                "recommended_products",
+                "slug",
+                "stockrecords",
+                "structure",
+                "title",
+                "upc",
+            ],
+        )
+
+        fieldz = get_mapped_fields(catalogue.ProductToModel, *model_to_product_fields)
+        self.assertListEqual(
+            sorted(fieldz),
+            [
+                "attributes",
+                "categories",
+                "children",
+                "date_created",
+                "date_updated",
+                "description",
+                "id",
+                "images",
+                "is_discountable",
+                "is_public",
+                "meta_description",
+                "meta_title",
+                "parent",
+                "priority",
+                "product_class",
+                "rating",
+                "recommended_products",
+                "slug",
+                "stockrecords",
+                "structure",
+                "title",
+                "upc",
+            ],
+        )
+
+        demfields = catalogue.ProductToModel.get_fields_impacted_by_mapping(
+            *model_to_product_fields
+        )
+        self.assertListEqual(
+            sorted(demfields),
+            [
+                "Category.code",
+                "Product.description",
+                "Product.is_discountable",
+                "Product.is_public",
+                "Product.meta_description",
+                "Product.meta_title",
+                "Product.parent",
+                "Product.priority",
+                "Product.slug",
+                "Product.structure",
+                "Product.title",
+                "Product.upc",
+                "ProductClass.slug",
+                "ProductImage.caption",
+                "ProductImage.code",
+                "ProductImage.display_order",
+                "ProductImage.original",
+                "StockRecord.num_allocated",
+                "StockRecord.num_in_stock",
+                "StockRecord.partner",
+                "StockRecord.partner_sku",
+                "StockRecord.price",
+                "StockRecord.price_currency",
+            ],
+        )

--- a/tests/resources/test_catalogue.py
+++ b/tests/resources/test_catalogue.py
@@ -1,10 +1,85 @@
 from django.test import TestCase
 
+from oscar.core.loading import get_model
+
+from odin.exceptions import ValidationError
 from oscar_odin import resources
+
+Product = get_model("catalogue", "Product")
 
 
 class TestProduct(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.maxDiff = None
+
     def test_init(self):
         target = resources.catalogue.ProductResource()
 
         self.assertIsNotNone(target)
+
+    def test_resource_with_price_needs_other_fields_to_work(self):
+        henk = resources.catalogue.ProductResource(
+            upc="klaas", price=10, structure=Product.STANDALONE, title="BATSIE"
+        )
+
+        with self.assertRaises(ValidationError) as error:
+            henk.full_clean()
+
+        self.assertDictEqual(
+            error.exception.error_messages,
+            {
+                "__all__": [
+                    "upc, currency and partner are required when specifying price or availability"
+                ],
+                "partner": ["Partner can not be empty."],
+            },
+        )
+
+        henk = resources.catalogue.ProductResource(
+            upc="klaas",
+            price=10,
+            structure=Product.STANDALONE,
+            currency="EUR",
+            title="BATSIE",
+        )
+
+        with self.assertRaises(ValidationError) as error:
+            henk.full_clean()
+
+        self.assertDictEqual(
+            error.exception.error_messages,
+            {
+                "__all__": [
+                    "upc, currency and partner are required when specifying price or availability"
+                ],
+                "partner": ["Partner can not be empty."],
+            },
+        )
+
+        henk = resources.catalogue.ProductResource(
+            upc="klaas",
+            price=10,
+            structure=Product.STANDALONE,
+            partner=1,
+            title="BATSIE",
+        )
+        henk.full_clean()
+
+    def test_resource_with_availability_needs_other_fields_to_work(self):
+        henk = resources.catalogue.ProductResource(
+            upc="klaas", availability=10, structure=Product.STANDALONE, title="BATSIE"
+        )
+
+        with self.assertRaises(ValidationError) as error:
+            henk.full_clean()
+
+        self.assertDictEqual(
+            error.exception.error_messages,
+            {
+                "__all__": [
+                    "upc, currency and partner are required when specifying price or availability"
+                ],
+                "partner": ["Partner can not be empty."],
+            },
+        )

--- a/tests/reverse/test_catalogue.py
+++ b/tests/reverse/test_catalogue.py
@@ -467,10 +467,13 @@ class MultipleProductReverseTest(TestCase):
         self.assertEqual(Product.objects.count(), 2)
 
     def test_create_product_with_related_fields(self):
+        partner = Partner.objects.create(name="klaas")
+
         product_resources = [
             ProductResource(
                 upc="1234323",
                 title="asdf1",
+                partner=partner,
                 slug="asdf-asdfasdf",
                 description="description",
                 structure=Product.STANDALONE,


### PR DESCRIPTION
It would be nice if we could find out for mapper what the exact data it is that they are mapping to.

The util ``get_mapped_fields`` can be used to check which field the mapper will actually update on the to_obj

``products_to_db`` accepts the ``fields_to_update`` parameter to do partial updates.

We can now use a combination of ``get_mapped_fields`` and ``ProductToModel.get_fields_impacted_by_mapping`` to check which fields are actually updated on the product model through a chain of mappings.

```
>>>     mapper = SomeMapperMappingToProductResource
>>>     mapped_fields = get_mapped_fields(mapper)
>>>     mapped_fields
{'upc', 'vat_rate', 'product_class', 'structure', 'price', 'title', 'partner'}
>>>     ProductToModel.get_fields_impacted_by_mapping(*mapped_fields)
['Product.upc', 'StockRecord.partner_sku', 'StockRecord.partner', 'ProductClass.slug', 'StockRecord.price', 'StockRecord.price_currency', 'Product.structure', 'Product.title']
```

The output can be directly passed to ``products_to_db`` as the ``fields_to_update`` parameter