### PR TITLE
Make ModelMapping able to be subclassed.

### DIFF
--- a/oscar_odin/mappings/model_mapper.py
+++ b/oscar_odin/mappings/model_mapper.py
@@ -8,11 +8,13 @@ from django.db.models.fields.reverse_related import (
 )
 from django.db.models.options import Options
 
-from odin.mapping import MappingBase, MappingMeta
+from odin.mapping import MappingBase
 from odin.utils import getmeta
 
+from .common import NonRegisterableMappingMeta
 
-class ModelMappingMeta(MappingMeta):
+
+class ModelMappingMeta(NonRegisterableMappingMeta):
     """Extended type of mapping meta."""
 
     def __new__(cls, name, bases, attrs):


### PR DESCRIPTION
Similar to;
https://github.com/django-oscar/django-oscar-odin/pull/60, but for the ModelMapping.

Otherwise subclassing is not possible, as odin would register the mapping in the cache and any new mapping with the same name would not be used.