### PR TITLE
Assign pk to duplicate instances for m2m like we do for foreignkeys

### DIFF
--- a/oscar_odin/mappings/context.py
+++ b/oscar_odin/mappings/context.py
@@ -358,8 +358,13 @@ class ModelMapperContext(dict):
             ):
                 fields = self.get_fields_to_update(relation.related_model)
                 if fields is not None:
+                    all_instances = instances_to_create
                     instances_to_create = self.validate_instances(instances_to_create)
                     relation.related_model.objects.bulk_create(instances_to_create)
+                    if len(all_instances) != len(instances_to_create):
+                        self.assign_pk_to_duplicate_instances(
+                            all_instances, instances_to_create
+                        )
 
         # Update many to many's
         for relation, instances_to_update in m2m_to_update.items():

--- a/oscar_odin/mappings/context.py
+++ b/oscar_odin/mappings/context.py
@@ -358,12 +358,15 @@ class ModelMapperContext(dict):
             ):
                 fields = self.get_fields_to_update(relation.related_model)
                 if fields is not None:
-                    all_instances = instances_to_create
-                    instances_to_create = self.validate_instances(instances_to_create)
-                    relation.related_model.objects.bulk_create(instances_to_create)
-                    if len(all_instances) != len(instances_to_create):
+                    validated_instances_to_create = self.validate_instances(
+                        instances_to_create
+                    )
+                    relation.related_model.objects.bulk_create(
+                        validated_instances_to_create
+                    )
+                    if len(instances_to_create) != len(validated_instances_to_create):
                         self.assign_pk_to_duplicate_instances(
-                            all_instances, instances_to_create
+                            instances_to_create, validated_instances_to_create
                         )
 
         # Update many to many's


### PR DESCRIPTION
Fixes potential errors like:
'Productattributevalue_value_multi_option': Cannot create m2m relationship ProductAttributeValue_value_multi_option - related model 'AttributeOption' is missing a primary key

Uses same logic as FK, but then for M2M